### PR TITLE
マップ要素の個数チェックを追加

### DIFF
--- a/inc/error.h
+++ b/inc/error.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/20 11:49:16 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/03/20 12:45:40 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/03/20 14:40:45 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,7 @@ typedef enum e_err_code
 	MAP_006,
 	MAP_007,
 	XXX_000,
+	NO_ERR
 }			t_err_code;
 
 # define GEN_000_STR "想定外のエラー\n"

--- a/inc/so_long.h
+++ b/inc/so_long.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 12:50:14 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/03/20 14:06:00 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/03/20 14:42:58 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,5 +36,6 @@ typedef struct s_game_data
 
 char		*get_map(char *map_path);
 bool		is_valid_data(t_map map);
+t_err_code	is_valid_map_count(t_map map);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 12:48:48 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/03/20 14:07:45 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/03/20 14:42:02 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,6 +86,7 @@ int	main(int ac, char **av)
 {
 	t_glx		*glx;
 	t_game_data	*data;
+	t_err_code	error;
 
 	(void)ac;
 	data = ft_calloc(1, sizeof(t_data));
@@ -93,6 +94,9 @@ int	main(int ac, char **av)
 	data->map->data = get_map(av[1]);
 	if (!is_valid_data(*data->map))
 		return (show_error(GEN_001), 1);
+	error = is_valid_map_count(*data->map);
+	if (error != NO_ERR)
+		return (show_error(error), 1);
 	glx = glx_init("so_long", 500, 500, 1000);
 	set_texture();
 	glx->hook(update, draw, clean);

--- a/src/map_validate.c
+++ b/src/map_validate.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/20 13:57:18 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/03/20 14:09:56 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/03/20 14:42:21 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,4 +35,50 @@ bool	is_valid_data(t_map map)
 			return (false);
 	}
 	return (true);
+}
+
+static int	_get_elem_count(t_map map, char elem)
+{
+	int	i;
+	int	count;
+
+	i = 0;
+	count = 0;
+	if (!map.data || map.data[i] == '\0')
+		return (0);
+	while (map.data[i])
+	{
+		if (map.data[i] == elem)
+			count++;
+		i++;
+	}
+	return (count);
+}
+
+/**
+ * @brief map要素の個数が正しいかチェックします。
+ *
+ * @param map
+ * @return t_err_code : err_codeを返します。
+ */
+t_err_code	is_valid_map_count(t_map map)
+{
+	int	c_count;
+	int	e_count;
+	int	p_count;
+
+	c_count = _get_elem_count(map, 'C');
+	e_count = _get_elem_count(map, 'E');
+	p_count = _get_elem_count(map, 'P');
+	if (c_count == 0)
+		return (ITM_000);
+	if (e_count == 0)
+		return (MAP_002);
+	if (e_count > 1)
+		return (MAP_003);
+	if (p_count == 0)
+		return (MAP_000);
+	if (p_count > 1)
+		return (MAP_001);
+	return (NO_ERR);
 }


### PR DESCRIPTION
fixed #27 
個数が正しくないときエラーにする処理を追加しました。